### PR TITLE
05.04.24.05.04

### DIFF
--- a/Assets/Code/API.cs
+++ b/Assets/Code/API.cs
@@ -28,7 +28,7 @@ namespace EDBR
             return result;
         }
 
-        const string faction_url = "https://elitebgs.app/api/ebgs/v5/factions?";
+        const string faction_url = "https://elitebgs.app/api/ebgs/v5/factions?systemDetails=true";
         const string system_url = "https://elitebgs.app/api/ebgs/v5/systems?factionDetails=true";
         const string station_url = "https://elitebgs.app/api/ebgs/v5/stations?";
         const string tick_url = "https://elitebgs.app/api/ebgs/v5/ticks?";
@@ -44,7 +44,7 @@ namespace EDBR
                 string url = ($"{faction_url}");
                 foreach(string s in sa)
                 {
-                    string query = ($"name={HttpUtility.UrlEncode(s)}&");
+                    string query = ($"&name={HttpUtility.UrlEncode(s)}");
                     url += query;
                 }
 
@@ -95,8 +95,7 @@ namespace EDBR
                     url += query;
                 }
 
-                Debug.Log($"REQUESTING PAGE {p} of {pages.Length} - {url}");
-                p++;
+                GameManager.Events.statusUpdated.Invoke($"REQUESTING DATA {p} of {pages.Length}");
 
                 using (UnityWebRequest request = UnityWebRequest.Get(url))
                 {
@@ -123,10 +122,14 @@ namespace EDBR
                             }
 
                             if(systems.Count > 0)
-                                GameManager.Session.addTrackedSystems(systems.ToArray());
+                                GameManager.Session.updateSystemFactionInfluence(systems.ToArray());
+
+                            if (p == pages.Length)
+                                GameManager.Events.statusUpdated.Invoke("READY");
                         }
                     }
                 }
+                p++;
             }
         }
     }

--- a/Assets/Code/DATA.cs
+++ b/Assets/Code/DATA.cs
@@ -8,10 +8,17 @@ namespace EDBR.Data
 {
     public static class Conversions
     {
+        public static system_details SystemDetailsFromJson(string json)
+        {
+            return JsonConvert.DeserializeObject<system_details>(json);
+        }
+        
         public static _system SystemFromJson(string json)
         {
             return JsonConvert.DeserializeObject<_system>(json);
         }
+
+
 
         public static _faction FactionFromJson(string json)
         {
@@ -19,7 +26,231 @@ namespace EDBR.Data
         }
     }
 
-    [global::System.Serializable]
+    //Part of the new API calls
+    [Serializable]
+    public class system_details
+    {
+        public class Conflict
+        {
+            [JsonProperty("type")]
+            public string type { get; set; }
+
+            [JsonProperty("status")]
+            public string status { get; set; }
+
+            [JsonProperty("faction1")]
+            public Faction1 faction1 { get; set; }
+
+            [JsonProperty("faction2")]
+            public Faction2 faction2 { get; set; }
+        }
+
+        public class Faction
+        {
+            [JsonProperty("name")]
+            public string name { get; set; }
+
+            [JsonProperty("name_lower")]
+            public string name_lower { get; set; }
+
+            [JsonProperty("faction_id")]
+            public string faction_id { get; set; }
+
+            public string state = "none";
+
+            public float influence = 0;
+        }
+
+        public class Faction1
+        {
+            [JsonProperty("faction_id")]
+            public string faction_id { get; set; }
+
+            [JsonProperty("name")]
+            public string name { get; set; }
+
+            [JsonProperty("name_lower")]
+            public string name_lower { get; set; }
+
+            [JsonProperty("station_id")]
+            public object station_id { get; set; }
+
+            [JsonProperty("stake")]
+            public string stake { get; set; }
+
+            [JsonProperty("stake_lower")]
+            public string stake_lower { get; set; }
+
+            [JsonProperty("days_won")]
+            public int days_won { get; set; }
+        }
+
+        public class Faction2
+        {
+            [JsonProperty("faction_id")]
+            public string faction_id { get; set; }
+
+            [JsonProperty("name")]
+            public string name { get; set; }
+
+            [JsonProperty("name_lower")]
+            public string name_lower { get; set; }
+
+            [JsonProperty("station_id")]
+            public object station_id { get; set; }
+
+            [JsonProperty("stake")]
+            public string stake { get; set; }
+
+            [JsonProperty("stake_lower")]
+            public string stake_lower { get; set; }
+
+            [JsonProperty("days_won")]
+            public int days_won { get; set; }
+        }
+
+        [JsonProperty("_id")]
+        public string _id { get; set; }
+
+        [JsonProperty("__v")]
+        public int __v { get; set; }
+
+        [JsonProperty("allegiance")]
+        public string allegiance { get; set; }
+
+        [JsonProperty("conflicts")]
+        public List<Conflict> conflicts { get; set; }
+
+        [JsonProperty("controlling_minor_faction")]
+        public string controlling_minor_faction { get; set; }
+
+        [JsonProperty("controlling_minor_faction_cased")]
+        public string controlling_minor_faction_cased { get; set; }
+
+        [JsonProperty("controlling_minor_faction_id")]
+        public string controlling_minor_faction_id { get; set; }
+
+        [JsonProperty("eddb_id")]
+        public string eddb_id { get; set; }
+
+        [JsonProperty("factions")]
+        public List<Faction> factions { get; set; }
+
+        [JsonProperty("government")]
+        public string government { get; set; }
+
+        [JsonProperty("name")]
+        public string name { get; set; }
+
+        [JsonProperty("name_lower")]
+        public string name_lower { get; set; }
+
+        [JsonProperty("population")]
+        public string population { get; set; }
+
+        [JsonProperty("primary_economy")]
+        public string primary_economy { get; set; }
+
+        [JsonProperty("secondary_economy")]
+        public string secondary_economy { get; set; }
+
+        [JsonProperty("security")]
+        public string security { get; set; }
+
+        [JsonProperty("state")]
+        public string state { get; set; }
+
+        [JsonProperty("system_address")]
+        public string system_address { get; set; }
+
+        [JsonProperty("updated_at")]
+        public string updated_at { get; set; }
+
+        [JsonProperty("x")]
+        public double x { get; set; }
+
+        [JsonProperty("y")]
+        public double y { get; set; }
+
+        [JsonProperty("z")]
+        public double z { get; set; }
+
+        [JsonProperty("name_aliases")]
+        public List<object> name_aliases { get; set; }
+    }
+
+    [Serializable]
+    public struct _faction
+    {
+        [JsonProperty("_id")]
+        public string _id { get; set; }
+
+        [JsonProperty("name_lower")]
+        public string name_lower { get; set; }
+
+        [JsonProperty("__v")]
+        public int __v { get; set; }
+
+        [JsonProperty("allegiance")]
+        public string allegiance { get; set; }
+
+        [JsonProperty("government")]
+        public string government { get; set; }
+
+        [JsonProperty("name")]
+        public string name { get; set; }
+
+        [JsonProperty("eddb_id")]
+        public string eddb_id { get; set; }
+
+        [JsonProperty("faction_presence")]
+        public List<FactionPresence> faction_presence { get; set; }
+
+        [JsonProperty("updated_at")]
+        public DateTime updated_at { get; set; }
+
+        [global::System.Serializable]
+        public class FactionPresence
+        {
+            [JsonProperty("system_name")]
+            public string system_name { get; set; }
+
+            [JsonProperty("system_name_lower")]
+            public string system_name_lower { get; set; }
+
+            [JsonProperty("system_id")]
+            public string system_id { get; set; }
+
+            [JsonProperty("state")]
+            public string state { get; set; }
+
+            [JsonProperty("influence")]
+            public double influence { get; set; }
+
+            [JsonProperty("happiness")]
+            public string happiness { get; set; }
+
+            [JsonProperty("active_states")]
+            public List<object> active_states { get; set; }
+
+            [JsonProperty("pending_states")]
+            public List<object> pending_states { get; set; }
+
+            [JsonProperty("recovering_states")]
+            public List<object> recovering_states { get; set; }
+
+            [JsonProperty("conflicts")]
+            public List<object> conflicts { get; set; }
+
+            [JsonProperty("updated_at")]
+            public DateTime updated_at { get; set; }
+
+            [JsonProperty("system_details")]
+            public system_details details { get; set; }
+        }
+    }
+
+    [Serializable]
     public struct _system
     {
         [JsonProperty("_id")]
@@ -145,7 +376,7 @@ namespace EDBR.Data
                 public string state { get; set; }
 
                 [JsonProperty("influence")]
-                public double influence { get; set; }
+                public float influence { get; set; }
 
                 [JsonProperty("happiness")]
                 public string happiness { get; set; }
@@ -214,74 +445,6 @@ namespace EDBR.Data
 
             [JsonProperty("days_won")]
             public int days_won { get; set; }
-        }
-    }
-
-    [global::System.Serializable]
-    public struct _faction
-    {
-        [JsonProperty("_id")]
-        public string _id { get; set; }
-
-        [JsonProperty("name_lower")]
-        public string name_lower { get; set; }
-
-        [JsonProperty("__v")]
-        public int __v { get; set; }
-
-        [JsonProperty("allegiance")]
-        public string allegiance { get; set; }
-
-        [JsonProperty("government")]
-        public string government { get; set; }
-
-        [JsonProperty("name")]
-        public string name { get; set; }
-
-        [JsonProperty("eddb_id")]
-        public string eddb_id { get; set; }
-
-        [JsonProperty("faction_presence")]
-        public List<FactionPresence> faction_presence { get; set; }
-
-        [JsonProperty("updated_at")]
-        public DateTime updated_at { get; set; }
-
-        [global::System.Serializable]
-        public class FactionPresence
-        {
-            [JsonProperty("system_name")]
-            public string system_name { get; set; }
-
-            [JsonProperty("system_name_lower")]
-            public string system_name_lower { get; set; }
-
-            [JsonProperty("system_id")]
-            public string system_id { get; set; }
-
-            [JsonProperty("state")]
-            public string state { get; set; }
-
-            [JsonProperty("influence")]
-            public double influence { get; set; }
-
-            [JsonProperty("happiness")]
-            public string happiness { get; set; }
-
-            [JsonProperty("active_states")]
-            public List<object> active_states { get; set; }
-
-            [JsonProperty("pending_states")]
-            public List<object> pending_states { get; set; }
-
-            [JsonProperty("recovering_states")]
-            public List<object> recovering_states { get; set; }
-
-            [JsonProperty("conflicts")]
-            public List<object> conflicts { get; set; }
-
-            [JsonProperty("updated_at")]
-            public DateTime updated_at { get; set; }
         }
     }
 

--- a/Assets/Code/MapManager.cs
+++ b/Assets/Code/MapManager.cs
@@ -14,7 +14,7 @@ public class MapManager : MonoBehaviour
 
     private void Awake()
     {
-        GameManager.Events.trackedSystemsUpdated.AddListener(updateSystems);
+        GameManager.Events.systemsUpdated.AddListener(updateSystems);
     }
 
     private void updateSystems()
@@ -26,12 +26,12 @@ public class MapManager : MonoBehaviour
         }
 
         //Populate new nodes
-        foreach (_system s in GameManager.Session.trackedSystems)
+        foreach (system_details s in GameManager.Session.trackedSystems)
         {
-            Vector3 pos = new Vector3(s.x, s.y, s.z);
+            Vector3 pos = new Vector3((float)s.x, (float)s.y, (float)s.z);
             GameObject newNode = Instantiate(node_prefab, pos, Quaternion.identity);
             newNode.GetComponentInChildren<MeshRenderer>().material.color = GameManager.Session.colorOfSystem(s);
-            newNode.GetComponent<Node>().system_name = s.name;
+            newNode.GetComponent<Node>().onClick.AddListener(() => GameManager.Session.setSelectedSystem(s._id));
 
             if(s.conflicts.Count > 0) newNode.transform.Find("conflict_particles").gameObject.SetActive(true);
 

--- a/Assets/Code/MouseOrbit.cs
+++ b/Assets/Code/MouseOrbit.cs
@@ -37,7 +37,7 @@ public class MouseOrbit : MonoBehaviour
 
     private void Awake()
     {
-        GameManager.Events.systemSelected.AddListener((v) => SetTarget(new Vector3(v.x, v.y, v.z)));
+        GameManager.Events.systemSelected.AddListener((v) => SetTarget(new Vector3((float)v.x, (float)v.y, (float)v.z)));
     }
 
     public void disableMovement()

--- a/Assets/Code/Node.cs
+++ b/Assets/Code/Node.cs
@@ -5,10 +5,9 @@ using UnityEngine.Events;
 
 public class Node : MonoBehaviour
 {
-    public string system_name;
-
+    public UnityEvent onClick = new UnityEvent();
     private void OnMouseUpAsButton()
     {
-        GameManager.Session.setSelectedSystem(system_name);
+        onClick.Invoke();
     }
 }

--- a/Assets/UI/Source/war_progress_body_left.png.meta
+++ b/Assets/UI/Source/war_progress_body_left.png.meta
@@ -7,7 +7,7 @@ TextureImporter:
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 1
+    sRGBTexture: 0
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
@@ -34,17 +34,17 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 2
     aniso: 1
     mipBias: 0
-    wrapU: 1
-    wrapV: 1
+    wrapU: 0
+    wrapV: 0
     wrapW: 0
   nPOTScale: 0
   lightmap: 0
   compressionQuality: 50
   spriteMode: 1
-  spriteExtrude: 1
+  spriteExtrude: 0
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
@@ -69,10 +69,10 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 3
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
+    maxTextureSize: 128
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0

--- a/Assets/UI/Source/war_progress_body_right.png.meta
+++ b/Assets/UI/Source/war_progress_body_right.png.meta
@@ -7,7 +7,7 @@ TextureImporter:
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 1
+    sRGBTexture: 0
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
@@ -34,17 +34,17 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 2
     aniso: 1
     mipBias: 0
-    wrapU: 1
-    wrapV: 1
+    wrapU: 0
+    wrapV: 0
     wrapW: 0
   nPOTScale: 0
   lightmap: 0
   compressionQuality: 50
   spriteMode: 1
-  spriteExtrude: 1
+  spriteExtrude: 0
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
@@ -69,10 +69,10 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 3
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
+    maxTextureSize: 128
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0


### PR DESCRIPTION
Fix #9

API now fetches raw system data during faction request. This includes system's XYZ coordinates, but does not include influence figures.

Influence figures can be obtained from the /systems endpoint using the factionDetails parameter. However, fetching this seems to be rate limited in some way.

So instead, we get raw system data from the /faction endpoint using the systemDetails param, and use that data as it is. Once a system has been placed in trackedSystems, a check is run to find which systems need influence figures, and a second API call set is run in the background to obtain this, and updates the tracked systems with new influence figures.

This results in immediate mapping and display of the systems, while the slower collection of influence figures can be run in the background.

A status indicator has been added in the lower left of the screen to indicate that these background activities are occurring. Systems will show "LOADING" until the influence for the given system has been updated.